### PR TITLE
Caffe/Keras support dilation and deconvolutions + other minor fixes

### DIFF
--- a/mmdnn/conversion/caffe/graph.py
+++ b/mmdnn/conversion/caffe/graph.py
@@ -65,7 +65,7 @@ LAYER_DESCRIPTORS = {
     'ContrastiveLoss': shape_scalar,
     'Convolution': shape_convolution,
     'Crop': shape_not_implemented,
-    'Deconvolution': shape_not_implemented,
+    'Deconvolution': shape_deconvolution,
     'Data': shape_data,
     'Dropout': shape_identity,
     'DummyData': shape_data,
@@ -91,7 +91,7 @@ LAYER_DESCRIPTORS = {
     'Scale': shape_identity,
     'Sigmoid': shape_identity,
     'SigmoidCrossEntropyLoss': shape_scalar,
-    'Silence': shape_not_implemented,
+    'Silence': shape_identity,
     'Softmax': shape_identity,
     'SoftmaxWithLoss': shape_scalar,
     'Split': shape_not_implemented,
@@ -195,7 +195,7 @@ class CaffeNode(object):
             k_h = k_w = 0
             s_h = s_w = 1
         p_h = self.get_kernel_value(params.pad_h, params.pad, 0, default=0)
-        p_w = self.get_kernel_value(params.pad_w, params.pad, 1, default=0)
+        p_w = self.get_kernel_value(params.pad_h, params.pad, 1, default=0)
         return KernelParameters(global_pooling, k_h, k_w, s_h, s_w, p_h, p_w)
 
     def __str__(self):
@@ -381,6 +381,8 @@ class GraphBuilder(object):
             # filter them out here.
             if (not exclude) and (phase == 'test'):
                 exclude = (layer.type == LayerType.Dropout)
+            if (not exclude):
+                exclude = (layer.type == LayerType.Silence)
             if not exclude:
                 if layer.name in filtered_layer_names:
                     for i in range(1, len(filtered_layer_names)):

--- a/mmdnn/conversion/caffe/graph.py
+++ b/mmdnn/conversion/caffe/graph.py
@@ -195,7 +195,7 @@ class CaffeNode(object):
             k_h = k_w = 0
             s_h = s_w = 1
         p_h = self.get_kernel_value(params.pad_h, params.pad, 0, default=0)
-        p_w = self.get_kernel_value(params.pad_h, params.pad, 1, default=0)
+        p_w = self.get_kernel_value(params.pad_w, params.pad, 1, default=0)
         return KernelParameters(global_pooling, k_h, k_w, s_h, s_w, p_h, p_w)
 
     def __str__(self):

--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -115,6 +115,7 @@ class NodeMapper(object):
         kwargs = cls.get_kernel_params(node, parent.output_shape)
 
         kwargs['kernel_shape'] = [node.kernel_parameters.k_h, node.kernel_parameters.k_w, node.parameters.num_output, parent.output_shape.channels]
+        kwargs['use_bias'] = node.parameters.bias_term
         if node.parameters.dilation:
             dilation = node.parameters.dilation[0]
             if dilation != 1:

--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -215,6 +215,9 @@ class NodeMapper(object):
 
     @classmethod
     def map_scale(cls, node):
+        raise NotImplementedError
+        # TODO: The gamma parameter has to be set (in node.data?) and this should work.
+        # Also, mean should be set to 0, and var to 1, just to be safe.
         scale_value = float(node.parameters.filler.value)
         kwargs = {'scale' : True, 'bias' : False, 'gamma' : scale_value, 'epsilon': 0}
         return Node.create('BatchNorm', **kwargs)

--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -181,7 +181,9 @@ class NodeMapper(object):
 
     @classmethod
     def map_softmax(cls, node):
-        return Node.create('Softmax')
+        kwargs = {}
+        cls._convert_output_shape(kwargs, node)
+        return Node.create('Softmax', **kwargs)
 
     @classmethod
     def map_lrn(cls, node):
@@ -228,12 +230,12 @@ class NodeMapper(object):
 
     @classmethod
     def map_abs_val(cls, node):
-        return Node.create('abs_val')
+        return Node.create('Abs')
 
     @classmethod
     def map_tanh(cls, node):
-        return Node.create('tanh')
+        return Node.create('Tanh')
 
     @classmethod
     def map_sigmoid(cls, node):
-        return Node.create('sigmoid')
+        return Node.create('Sigmoid')

--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -101,6 +101,10 @@ class NodeMapper(object):
         kwargs = cls.get_kernel_params(node, parent.output_shape)
         kwargs['kernel_shape'] = [node.kernel_parameters.k_h, node.kernel_parameters.k_w, parent.output_shape.channels, node.parameters.num_output]
         kwargs['use_bias'] = node.parameters.bias_term
+        if node.parameters.dilation:
+            dilation = node.parameters.dilation[0]
+            if dilation != 1:
+                kwargs['dilations'] = [1, dilation, dilation, dilation, 1]
         kwargs['group'] = node.parameters.group
         return Node.create('Conv', **kwargs)
 
@@ -111,6 +115,10 @@ class NodeMapper(object):
         kwargs = cls.get_kernel_params(node, parent.output_shape)
 
         kwargs['kernel_shape'] = [node.kernel_parameters.k_h, node.kernel_parameters.k_w, node.parameters.num_output, parent.output_shape.channels]
+        if node.parameters.dilation:
+            dilation = node.parameters.dilation[0]
+            if dilation != 1:
+                kwargs['dilations'] = [1, dilation, dilation, dilation, 1]
         kwargs['group'] = node.parameters.group
         return Node.create('ConvTranspose', **kwargs)
 

--- a/mmdnn/conversion/caffe/shape.py
+++ b/mmdnn/conversion/caffe/shape.py
@@ -4,9 +4,16 @@ import math
 TensorShape = namedtuple('TensorShape', ['batch_size', 'channels', 'height', 'width'])
 
 
-def get_filter_output_shape(i_h, i_w, params, round_func):
-    o_h = (i_h + 2 * params.p_h - params.k_h) / float(params.s_h) + 1
-    o_w = (i_w + 2 * params.p_w - params.k_w) / float(params.s_w) + 1
+def get_kernel_extents(params, dilation):
+    ko_h = dilation * (int(params.k_h) - 1) + 1
+    ko_w = dilation * (int(params.k_w) - 1) + 1
+    return ko_h, ko_w
+
+def get_filter_output_shape(i_h, i_w, dilation, params, round_func):
+    ko_h, ko_w = get_kernel_extents(params, dilation)
+
+    o_h = (i_h + 2 * params.p_h - ko_h) / float(params.s_h) + 1
+    o_w = (i_w + 2 * params.p_w - ko_w) / float(params.s_w) + 1
     return (int(round_func(o_h)), int(round_func(o_w)))
 
 
@@ -14,8 +21,10 @@ def get_strided_kernel_output_shape(node, round_func):
     assert node.layer is not None
     input_shape = node.get_only_parent()[0].output_shape
     params = node.kernel_parameters
+    dilation = 1 if len(node.parameters.dilation) == 0 else node.parameters.dilation[0]
+
     o_h, o_w = get_filter_output_shape(input_shape.height, input_shape.width,
-                                       params, round_func)
+                                       dilation, params, round_func)
     params = node.parameters
     has_c_o = hasattr(params, 'num_output')
     c = params.num_output if has_c_o else input_shape.channels
@@ -30,10 +39,7 @@ def shape_deconvolution(node):
     params = node.kernel_parameters
     dilation = node.parameters.dilation[0]
 
-    # Kernel extents
-    ko_h = dilation * (int(params.k_h) - 1) + 1
-    ko_w = dilation * (int(params.k_w) - 1) + 1
-    # Output height and with
+    ko_h, ko_w = get_kernel_extents(params, dilation)
     o_h = int(params.s_h) * (input_shape.height - 1) + ko_h - 2 * int(params.p_h)
     o_w = int(params.s_w) * (input_shape.width - 1) + ko_w - 2 * int(params.p_w)
 

--- a/mmdnn/conversion/caffe/transformer.py
+++ b/mmdnn/conversion/caffe/transformer.py
@@ -250,7 +250,8 @@ class BatchNormPreprocessor(object):
 
             if len(np.squeeze(mean) == 1):
                 mean = np.squeeze(mean)
-                variance = np.squeeze(mean)
+                variance = np.squeeze(variance)
+                scaling_factor = np.squeeze(scaling_factor)
 
             mean *= scaling_factor
             variance *= scaling_factor

--- a/mmdnn/conversion/caffe/transformer.py
+++ b/mmdnn/conversion/caffe/transformer.py
@@ -318,6 +318,7 @@ class CaffeTransformer(object):
             if target_toolkit not in ('caffe', 'caffe2'):
                 graph = graph.transformed([DataReshaper({ # Reshape the parameters to TensorFlow's ordering
                     NodeKind.Convolution: (2, 3, 1, 0), # (c_o, c_i, h, w) -> (h, w, c_i, c_o)
+                    NodeKind.Deconvolution: (2, 3, 1, 0), # (c_o, c_i, h, w) -> (h, w, c_i, c_o)
                     NodeKind.InnerProduct: (1, 0) # (c_o, c_i) -> (c_i, c_o)
                 }),
                     ParameterNamer() # Convert parameters to dictionaries

--- a/mmdnn/conversion/caffe/transformer.py
+++ b/mmdnn/conversion/caffe/transformer.py
@@ -245,7 +245,7 @@ class BatchNormPreprocessor(object):
             assert len(node.data) == 3
             mean, variance, scale = node.data
             # Prescale the stats
-            scaling_factor = 1.0 / scale if scale != 0 else 0
+            scaling_factor = float(1.0 / scale) if float(scale) != 0 else 0
             mean *= scaling_factor
             variance *= scaling_factor
             # Replace with the updated values

--- a/mmdnn/conversion/keras/keras2_emitter.py
+++ b/mmdnn/conversion/keras/keras2_emitter.py
@@ -71,6 +71,8 @@ def load_weights(model, weight_file):
                 current_layer_parameters = [cur_dict['depthwise_filter'], cur_dict['pointwise_filter']]
                 if 'bias' in cur_dict:
                     current_layer_parameters.append(cur_dict['bias'])
+            elif layer.__class__.__name__ == "Conv2DTranspose":
+                current_layer_parameters = cur_dict
             else:
                 # rot weights
                 current_layer_parameters = [cur_dict['weights']]
@@ -195,7 +197,7 @@ def KitModel(weight_file = None):
 
     def emit_ConvTranspose(self, IR_node):
         assert IR_node.get_attr('group', 1) == 1
-        filters = IR_node.get_attr('kernel_shape')[-1]
+        filters = IR_node.get_attr('kernel_shape')[-2]
         filters_str = 'filters = {}'.format(filters)
         input_node, padding = self._defuse_padding(IR_node)
 

--- a/mmdnn/conversion/keras/keras2_emitter.py
+++ b/mmdnn/conversion/keras/keras2_emitter.py
@@ -71,8 +71,6 @@ def load_weights(model, weight_file):
                 current_layer_parameters = [cur_dict['depthwise_filter'], cur_dict['pointwise_filter']]
                 if 'bias' in cur_dict:
                     current_layer_parameters.append(cur_dict['bias'])
-            elif layer.__class__.__name__ == "Conv2DTranspose":
-                current_layer_parameters = cur_dict
             else:
                 # rot weights
                 current_layer_parameters = [cur_dict['weights']]

--- a/mmdnn/conversion/keras/keras2_emitter.py
+++ b/mmdnn/conversion/keras/keras2_emitter.py
@@ -203,7 +203,7 @@ def KitModel(weight_file = None):
         if not dilations:
             dilations = [1] * len(IR_node.get_attr('kernel_shape'))
 
-        self.add_body(1, "{:<15} = layers.Conv2DTranpose(name='{}', {}, kernel_size=({}), strides=({}), dilation_rate=({}), padding='{}', use_bias={})({})".format(
+        self.add_body(1, "{:<15} = layers.Conv2DTranspose(name='{}', {}, kernel_size=({}), strides=({}), dilation_rate=({}), padding='{}', use_bias={})({})".format(
             IR_node.variable_name,
             IR_node.name,
             filters_str,


### PR DESCRIPTION
I was looking to convert a [Caffe trained colorization network](http://richzhang.github.io/colorization/) to Keras, and a few things were missing, so I added them. I didn't succeed fully :(, so whether this all works or not is not entirely certain. It is possible that some filters need flipping or something, I am unable to test this at this moment (don't have Caffe configured on this machine).

Changes:
* **Support deconvolutions/transposed convolutions**, both in Caffe input and Keras output. 
* **Dilation factors in any type of convolution**, both in Caffe input and Keras output. 
* **Ignore silence layers in Caffe graphs**
* **Minor fix:** BatchNorm weights of shape `(1,1,1,64)`or similar, are now reshaped to `(64,)` to prevent broadcasting issues.
* **Fix typo:** *paramters -> parameters*.

There's also a stub for support for Scale layer. I figured a scale layer is equivalent to a BatchNorm layer with gamma weights equal to the scale factor, no bias, var=1 and mean=0. Unfortunately the Scale layer doesn't necessarily have learned weights, so it doesn't appear in the graph lists. I'm not sure where and how to add it. Maybe one of the main contributors can have a look at this and finish this up? :)