### PR TITLE
NotImplementError() --> NotImplementedError()

### DIFF
--- a/mmdnn/conversion/examples/imagenet_test.py
+++ b/mmdnn/conversion/examples/imagenet_test.py
@@ -203,7 +203,7 @@ class TestKit(object):
 
 
     def dump(self, path = None):
-        raise NotImplementError()
+        raise NotImplementedError()
 
 
 '''


### PR DESCRIPTION
Added the missing "__ed__".
* https://docs.python.org/3/library/exceptions.html#NotImplementedError

Caught by flake8