### PR TITLE
keras graphs: differentiate between _inbound_nodes and inbound_nodes

### DIFF
--- a/mmdnn/conversion/keras/keras2_graph.py
+++ b/mmdnn/conversion/keras/keras2_graph.py
@@ -44,16 +44,31 @@ class Keras2Graph(Graph):
         for i, layer in enumerate(self.model.layers):
             self.layer_map[layer.name] = Keras2GraphNode(layer)
             self.layer_name_map[layer.name] = layer.name
-            # if hasattr(layer, '_inbound_nodes'):
-            for node in layer._inbound_nodes:
-                # print (dir(node), type(node), type(layer))
-                # assert False
-                # for pred in node._inbound_nodes:
-                for pred in node.inbound_layers:
-                    if pred.name not in self.layer_map:
-                        self.layer_map[pred.name] = Keras2GraphNode(pred)
-                        self.layer_name_map[pred.name] = pred.name
-                    self._make_connection(pred.name, layer.name)
+
+            # After keras 2.1 _inbound_nodes got changed to inbound_nodes
+            # so check which one is present
+            # otherwise the conversion will fail
+            # for models of the wrong keras type
+            if hasattr(layer, '_inbound_nodes'):
+                for node in layer._inbound_nodes:
+                    # print (dir(node), type(node), type(layer))
+                    # assert False
+                    # for pred in node._inbound_nodes:
+                    for pred in node.inbound_layers:
+                        if pred.name not in self.layer_map:
+                            self.layer_map[pred.name] = Keras2GraphNode(pred)
+                            self.layer_name_map[pred.name] = pred.name
+                        self._make_connection(pred.name, layer.name)
+            else:
+                for node in layer.inbound_nodes:
+                    # print (dir(node), type(node), type(layer))
+                    # assert False
+                    # for pred in node._inbound_nodes:
+                    for pred in node.inbound_layers:
+                        if pred.name not in self.layer_map:
+                            self.layer_map[pred.name] = Keras2GraphNode(pred)
+                            self.layer_name_map[pred.name] = pred.name
+                        self._make_connection(pred.name, layer.name)
 
         # Kit: TODO
         # Duplicate models for weight sharing


### PR DESCRIPTION
In Keras>2.1 _inbound_nodes got renamed to inbound_nodes (leading underscore removed). If you convert a newer model, it won't work. I changed it so it checks if _inbound_nodes is present - if not, it uses inbound_nodes.

Should work with old and new models now.