### PR TITLE
Solve setup problem: UnicodeDecodeError: 'gbk' codec can't decode...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # Get the long description from the README file
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from setuptools import setup, find_packages
+from io import open
 
 # Get the long description from the README file
 with open('README.md', encoding='utf-8') as f:


### PR DESCRIPTION
When install the lastest MMdnn on windows10 from github with commands:

```bash
pip install -U git+https://github.com/Microsoft/MMdnn.git@master
```

f.read() in setup.py line 6 raised a UnicodeDecodeError:

```
Collecting git+https://github.com/Microsoft/MMdnn.git@master
  Cloning https://github.com/Microsoft/MMdnn.git (to master) to c:\users\luuil\appdata\local\temp\pip-493wsby0-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\luuil\AppData\Local\Temp\pip-493wsby0-build\setup.py", line 6, in <module>
        long_description = f.read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x9a in position 3379: illegal multibyte sequence
```