### PR TITLE
coreml to caffe tests passed

### DIFF
--- a/mmdnn/conversion/coreml/coreml_parser.py
+++ b/mmdnn/conversion/coreml/coreml_parser.py
@@ -502,7 +502,9 @@ class CoremlParser(Parser):
 
         # For concat axis
         # NO axis in coreml, so set the last axis
-        IR_node.attr['axis'].i = -1
+        IR_node.attr['axis'].i = len(CoremlParser.shape_dict[source_node.layer.output[0]])-1 -1
+        # The first -1 means in coreml there is one-more axis,
+        # The second -1 means the last axis
 
         return IR_node
 
@@ -762,7 +764,9 @@ class CoremlParser(Parser):
         # input edge
         self.convert_inedge(coreml_node, IR_node)
 
+        # bias
         IR_node.attr['use_bias'].b = coreml_node_scale.hasBias
+
 
         self.set_weight(coreml_node_layer.name, "scale", np.array(coreml_node_scale.scale.floatValue))
 

--- a/mmdnn/conversion/mxnet/mxnet_emitter.py
+++ b/mmdnn/conversion/mxnet/mxnet_emitter.py
@@ -807,7 +807,7 @@ def predict(model, labels, url):
         ndim = len(IR_node.layer.attr['_output_shapes'].list.shape[0].dim)
         if axis == 0:
             return 0
-        elif axis == ndim - 1 or axis == -1:
+        elif axis == ndim - 1:
             return 1
         else:
             return axis + 1

--- a/tests/test_conversion_imagenet.py
+++ b/tests/test_conversion_imagenet.py
@@ -738,11 +738,11 @@ class TestModels(CorrectnessTest):
         },
 
         'coreml' : {
-            'inception_v3' : [CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
-            'mobilenet'    : [CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
-            'resnet50'     : [CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
+            'inception_v3' : [CaffeEmit, CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
+            'mobilenet'    : [CaffeEmit, CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
+            'resnet50'     : [CaffeEmit, CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
             'tinyyolo'     : [CoreMLEmit, KerasEmit, TensorflowEmit],
-            'vgg16'        : [CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
+            'vgg16'        : [CaffeEmit, CoreMLEmit, KerasEmit, MXNetEmit, TensorflowEmit],
         },
 
         'darknet' : {


### PR DESCRIPTION
tiny-yolo still crack because the padding in caffe is symmetric like mxnet.