### PR TITLE
Set ONNX model opset to version 6

### DIFF
--- a/mmdnn/conversion/onnx/onnx_emitter.py
+++ b/mmdnn/conversion/onnx/onnx_emitter.py
@@ -84,7 +84,7 @@ def KitModel(weight_file = None):
                                                                                              ', '.join(
                                                                                                  self.initializer))
                       )
-        self.add_body(1, "return helper.make_model(graph)")
+        self.add_body(1, "return helper.make_model(graph, opset_imports=[helper.make_opsetid('', 6)])")
         return self.body_code
 
     def run(self, dstNetworkPath, dstWeightPath=None, phase='test'):


### PR DESCRIPTION
The current ONNX emitter aims to ONNX opset version 6.