### PR TITLE
Add count_include_pad attribute for caffe parsed AveragePool for ONNX.

### DIFF
--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -168,6 +168,7 @@ class NodeMapper(object):
             kwargs['pooling_type'] = 'MAX'
         elif node.parameters.pool == 1:
             kwargs['pooling_type'] = 'AVG'
+            kwargs['count_include_pad'] = 1
         else:
             # Stochastic pooling, for instance.
             raise ConversionError('Unsupported pooling type.')

--- a/mmdnn/conversion/onnx/onnx_emitter.py
+++ b/mmdnn/conversion/onnx/onnx_emitter.py
@@ -360,19 +360,21 @@ def KitModel(weight_file = None):
                     op_name = 'AveragePool'
                 elif pooling_type == 'MAX':
                     op_name = 'MaxPool'
+                count_include_pad = IR_node.get_attr('count_include_pad', 0)
                 kernel_shape = list(IR_node.get_attr('kernel_shape')[1:-1])
                 pads = IR_node.get_attr('pads')
                 pad_length = len(pads)
                 pads = pads[1:pad_length // 2 - 1] + pads[pad_length // 2 + 1:pad_length - 1]
                 strides = list(IR_node.get_attr('strides')[1:-1])
-                self.add_body(1, "{:15} = helper.make_node('{}', inputs=['{}'],outputs=['{}'], kernel_shape={}, pads={}, strides={})".format(
+                self.add_body(1, "{:15} = helper.make_node('{}', inputs=['{}'],outputs=['{}'], kernel_shape={}, pads={}, strides={}{})".format(
                                   IR_node.variable_name,
                                   op_name,
                                   self.parent_variable_name(IR_node),
                                   IR_node.variable_name,
                                   kernel_shape,
                                   pads,
-                                  strides))
+                                  strides,
+                                  "" if count_include_pad == 0 else ", count_include_pad=1"))
                 self.nodes.append(IR_node.variable_name)
             else:
                 print("OnnxEmitter has not supported Pool type [%s]." % (pooling_type))

--- a/mmdnn/conversion/onnx/onnx_parser.py
+++ b/mmdnn/conversion/onnx/onnx_parser.py
@@ -44,8 +44,6 @@ class ONNXParser(Parser):
         self.onnx_graph.build()
         self.weight_loaded = True
 
-    def rename_Conv(self, source_node):
-
     def rename_UNKNOWN(self, source_node):
         if source_node.type in self.skip_type:
             return


### PR DESCRIPTION
Caffe's average pool count numbers in kernel covered numbers into denominator even the number is in pad area, while other frameworks (like CNTK) only count valid numbers into denominator without pad area. That's why I set onnx::AveragePool::count_include_pad=1 for caffe parsed average pool node. For issue #463 .
Reference for this attribute: https://github.com/onnx/onnx/blob/master/docs/Operators.md#AveragePool
