### PR TITLE
fix syntax errors of ops.pbtxt

### DIFF
--- a/mmdnn/conversion/common/IR/ops.pbtxt
+++ b/mmdnn/conversion/common/IR/ops.pbtxt
@@ -26,7 +26,7 @@ op {
   attr {
       name: "axis"
       type: "int"
-      description: "The axis that should be normalized (typically the features axis). For instance, after a Convolution2D layer with data_format="channels_first", set axis=1 in BatchNormalization"
+      description: "The axis that should be normalized (typically the features axis). For instance, after a Convolution2D layer with data_format=\"channels_first\", set axis=1 in BatchNormalization"
   }
   attr {
       name: "momentum"
@@ -109,7 +109,6 @@ op {
       b: true
     }
     description: "If use bias"
-    }
   }
   attr {
     name: "dilations"
@@ -310,7 +309,6 @@ op {
       b: true
     }
     description: "If use bias"
-    }
   }
   summary: "Y = W * X + b"
   description: "Not in Tensorflow. Dense operator in Keras. parameters are [weights], [bias]."
@@ -432,12 +430,12 @@ op {
   attr {
     name: "ends"
     description: "`ends[i]` is like `begin` with the exception that `end_mask` is used to determine full ranges."
-    pe: "list(int)"
+    type: "list(int)"
   }
   attr {
     name: "strides"
     description: "`strides[i]` specifies the increment in the `i`th specification after extracting a given element. Negative indices will reverse the original order. Out or range values are clamped to `[0,dim[i]) if slice[i]>0` or `[-1,dim[i]-1] if slice[i] < 0`"
-    pe: "list(int)"
+    type: "list(int)"
   }
   summary: "Return a strided slice from `input`."
   description: "Note, most python users will want to use the Python `Tensor.__getitem__` or `Variable.__getitem__` rather than this op directly.  The goal of this op is to produce a new tensor with a subset of the elements from the `n` dimensional `input` tensor. The subset is chosen using a sequence of `m` sparse range specifications encoded into the arguments of this function. Note, in some cases `m` could be equal to `n`, but this need not be the case. Each range specification entry can be one of the following:  - An ellipsis (...). Ellipses are used to imply zero or more   dimensions of full-dimension selection and are produced using   `ellipsis_mask`. For example, `foo[...]` is the identity slice.  - A new axis. This is used to insert a new shape=1 dimension and is   produced using `new_axis_mask`. For example, `foo[:, ...]` where   `foo` is shape `(3, 4)` produces a `(1, 3, 4)` tensor.   - A range `begin:end:stride`. This is used to specify how much to choose from   a given dimension. `stride` can be any integer but 0.  `begin` is an integer   which represents the index of the first value to select while `end` represents   the index of the last value to select. The number of values selected in each   dimension is `end - begin` if `stride > 0` and `begin - end` if `stride < 0`.   `begin` and `end` can be negative where `-1` is the last element, `-2` is   the second to last. `begin_mask` controls whether to replace the explicitly   given `begin` with an implicit effective value of `0` if `stride > 0` and   `-1` if `stride < 0`. `end_mask` is analogous but produces the number   required to create the largest open interval. For example, given a shape   `(3,)` tensor `foo[:]`, the effective `begin` and `end` are `0` and `3`. Do   not assume this is equivalent to `foo[0:-1]` which has an effective `begin`   and `end` of `0` and `2`. Another example is `foo[-2::-1]` which reverses the   first dimension of a tensor while dropping the last two (in the original   order elements). For example `foo = [1,2,3,4]; foo[-2::-1]` is `[4,3]`.  - A single index. This is used to keep only elements that have a given   index. For example (`foo[2, :]` on a shape `(5,6)` tensor produces a   shape `(6,)` tensor. This is encoded in `begin` and `end` and   `shrink_axis_mask`.  Each conceptual range specification is encoded in the op\'s argument. This encoding is best understand by considering a non-trivial example. In particular, `foo[1, 2:4, None, ..., :-3:-1, :]` will be encoded as  ``` begin = [1, 2, x, x, 0, x] # x denotes don\'t care (usually 0) end = [2, 4, x, x, -3, x] strides = [1, 1, x, x, -1, 1] begin_mask = 1<<4 | 1 << 5 = 48 end_mask = 1<<5 = 32 ellipsis_mask = 1<<3 = 8 new_axis_mask = 1<<2 4 shrink_axis_mask = 1<<0 ```  In this case if `foo.shape` is (5, 5, 5, 5, 5, 5) the final shape of the slice becomes (2, 1, 5, 5, 2, 5). Let us walk step by step through each argument specification.  1.  The first argument in the example slice is turned into `begin = 1` and `end = begin + 1 = 2`. To disambiguate from the original spec `2:4` we also set the appropriate bit in `shrink_axis_mask`.  2. `2:4` is contributes 2, 4, 1 to begin, end, and stride. All masks have zero bits contributed.  3. None is a synonym for `tf.newaxis`. This means insert a dimension of size 1 dimension in the final shape. Dummy values are contributed to begin, end and stride, while the new_axis_mask bit is set.  4. `...` grab the full ranges from as many dimensions as needed to fully specify a slice for every dimension of the input shape.  5. `:-3:-1` shows the use of negative indices. A negative index `i` associated with a dimension that has shape `s` is converted to a positive index `s + i`. So `-1` becomes `s-1` (i.e. the last element). This conversion is done internally so begin, end and strides receive x, -3, and -1. The appropriate begin_mask bit is set to indicate the start range is the full range (ignoring the x).  6. `:` indicates that the entire contents of the corresponding dimension is selected. This is equivalent to `::` or `0::1`. begin, end, and strides receive 0, 0, and 1, respectively. The appropriate bits in `begin_mask` and `end_mask` are also set.  *Requirements*:   `0 != strides[i] for i in [0, m)`   `ellipsis_mask must be a power of two (only one ellipsis)`"
@@ -512,10 +510,10 @@ op {
         s: "SYMMETRIC"
       }
     }
-    attr {
-      name: "constant_values"
-      type: "float"
-    }
+  }
+  attr {
+    name: "constant_values"
+    type: "float"
   }
   summary: "Padding Layer."
   description: "Not directly mapping in Tensorflow. Pads a tensor."


### PR DESCRIPTION
There are some syntax errors, after fixing, the operators can be loaded by 
```python
import os
from tensorflow.core.framework import op_def_pb2
from google.protobuf.text_format import Merge
from google.protobuf.json_format import MessageToDict

def get_ops():
    ops_file = 'ops.pbtxt'

    ops = op_def_pb2.OpList()
    with open(ops_file) as fn:
        Merge(fn.read(), ops)
    ops_list = [MessageToDict(op) for op in ops.op]
    return ops_list

```