### PR TITLE
Undefined name: printf() --> print()

### DIFF
--- a/tests/gen_test.py
+++ b/tests/gen_test.py
@@ -382,7 +382,7 @@ def prepare_env(FLAGS):
     if (not os.path.exists(output_dir)):
         os.mkdir(output_dir)
     if ((not os.path.isdir(output_dir)) or (not os.path.exists(output_dir))):
-        printf('Cannot create target output directory: "{0}"'.format(output_dir))
+        print('Cannot create target output directory: "{0}"'.format(output_dir))
         return False
     return True
 


### PR DESCRIPTION
__printf__ is an _undefined name_ in this context which has the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/MMdnn on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mmdnn/conversion/torch/torch_graph.py:18:15: F821 undefined name 'PyTorchGraphNode'
        super(PyTorchGraphNode, self).__init__(layer)
              ^
./mmdnn/conversion/examples/paddle/extract_model.py:80:63: F821 undefined name 'architecture'
    fn = download_file(MODEL_URL[args.network], local_fname = architecture + '.tar.gz', directory=args.output_dir)
                                                              ^
./mmdnn/conversion/examples/paddle/extract_model.py:96:20: F821 undefined name 'architecture'
    if 'resnet' in architecture:
                   ^
./mmdnn/conversion/examples/paddle/extract_model.py:98:21: F821 undefined name 'architecture'
        depth = int(architecture.strip('resnet'))
                    ^
./mmdnn/conversion/examples/paddle/extract_model.py:100:10: F821 undefined name 'architecture'
    elif architecture == 'vgg16':
         ^
./mmdnn/conversion/examples/paddle/extract_model.py:104:42: F821 undefined name 'architecture'
        print("Not support for {} yet.", architecture)
                                         ^
./mmdnn/conversion/examples/paddle/extract_model.py:107:43: F821 undefined name 'architecture'
    dump_v2_config(out, args.output_dir + architecture + '.bin')
                                          ^
./mmdnn/conversion/examples/paddle/extract_model.py:110:85: F821 undefined name 'architecture'
    print("Model {} is saved as {} and {}.".format(args.network,  args.output_dir + architecture + '.bin', fn))
                                                                                    ^
./mmdnn/conversion/examples/paddle/extract_model.py:121:24: F821 undefined name 'parameters_file'
        with gzip.open(parameters_file, 'r') as f:
                       ^
./mmdnn/conversion/darknet/cfg.py:186:9: F821 undefined name 'convert2cpu'
        convert2cpu(conv_model.bias.data).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:187:9: F821 undefined name 'convert2cpu'
        convert2cpu(conv_model.weight.data).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:204:9: F821 undefined name 'convert2cpu'
        convert2cpu(bn_model.bias.data).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:205:9: F821 undefined name 'convert2cpu'
        convert2cpu(bn_model.weight.data).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:206:9: F821 undefined name 'convert2cpu'
        convert2cpu(bn_model.running_mean).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:207:9: F821 undefined name 'convert2cpu'
        convert2cpu(bn_model.running_var).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:208:9: F821 undefined name 'convert2cpu'
        convert2cpu(conv_model.weight.data).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:219:9: F821 undefined name 'convert2cpu'
        convert2cpu(bias).numpy().tofile(fp)
        ^
./mmdnn/conversion/darknet/cfg.py:222:9: F821 undefined name 'convert2cpu'
        convert2cpu(weight).numpy().tofile(fp)
        ^
./tests/gen_test.py:385:9: F821 undefined name 'printf'
        printf('Cannot create target output directory: "{0}"'.format(output_dir))
        ^
19    F821 undefined name 'convert2cpu'
19
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree