### PR TITLE
preserve order when converting batchnorm+scale layers

### DIFF
--- a/mmdnn/conversion/caffe/graph.py
+++ b/mmdnn/conversion/caffe/graph.py
@@ -145,9 +145,10 @@ class CaffeNode(object):
         self.output_shape = None
         self.metadata = {}
 
-    def add_parent(self, parent_node, from_output):
+    def add_parent(self, parent_node, from_output, index=None):
         assert parent_node not in self.parents
-        self.parents.append((parent_node, from_output))
+        index = len(self.parents) if index is None else index
+        self.parents.insert(index, (parent_node, from_output))
         if self not in parent_node.children:
             parent_node.children.append(self)
 

--- a/mmdnn/conversion/caffe/transformer.py
+++ b/mmdnn/conversion/caffe/transformer.py
@@ -176,8 +176,9 @@ class SubNodeFuser(object):
                 continue
             # Rewrite the fused node's children to its parent.
             for child in node.children:
-                child.parents = [(input, idx) for input, idx in child.parents if input != node]
-                child.add_parent(parent, from_output)
+                index = [n for n, (input, idx) in enumerate(child.parents) if input == node][0]
+                child.parents.pop(index)
+                child.add_parent(parent, from_output, index)
             # Disconnect the fused node from the graph.
             parent.children.remove(node)
             fused_nodes.append(node)


### PR DESCRIPTION
The caffe converter does not preserve node order when converting batchnorm followed by scale layers. Take the following (very simple) network as an example:

```
name: "DemoNet"

layer {
  name: "data"
  type: "Input"
  top: "data"
  input_param: {
    shape: {
      dim: 1
      dim: 3
      dim: 224
      dim: 224
    }
  }
}
layer {
  name: "conv1"
  type: "Convolution"
  bottom: "data"
  top: "conv1"
  convolution_param {
    num_output: 64
    bias_term: false
    pad: 3
    kernel_size: 7
    stride: 2
  }
}
layer {
  name: "conv1/bn"
  type: "BatchNorm"
  bottom: "conv1"
  top: "conv1/bn"
  batch_norm_param {
    use_global_stats: true
  }
}
layer {
  name: "conv1/bn/scale"
  type: "Scale"
  bottom: "conv1/bn"
  top: "conv1/bn/scale"
  scale_param {
    bias_term: true
  }
}
layer {
  name: "concat2"
  bottom: "conv1/bn/scale"
  bottom: "conv1"
  top: "concat2"
  type: "Concat"
  concat_param {
    axis: 1
  }
}
layer {
  name: "pool3"
  type: "Pooling"
  bottom: "concat2"
  top: "pool3"
  pooling_param {
    pool: MAX
    kernel_size: 112
    stride: 1
  }
}
layer {
  name: "classifier"
  type: "InnerProduct"
  inner_product_param {
    num_output: 1000
  }
  bottom: "pool3"
  top: "classifier"
}
```
you can see that the Concat layer (concat2) takes two layers as input (conv1/bn/scale and conv1) and the resulting output is affected by the order of the inputs. The current code, while merging batchorm and scale layers, moves the new batchnorm layer at the bottom of the list, possibly breaking the layer output. The output for the concat2 layer to pytorch is the following:

```
concat2 = torch.cat((conv1, conv1_bn), 1)
```
which is the opposite of what one would expect.

This pull request proposes a simple way of fixing this misbehavior, by checking the index position of the input layer being removed and later inserting the new one in the right position instead of appending it at the end.