### PR TITLE
fix attribute error caused by inconsistent naming on UpSampling2D layer

### DIFF
--- a/mmdnn/conversion/cntk/cntk_emitter.py
+++ b/mmdnn/conversion/cntk/cntk_emitter.py
@@ -766,7 +766,7 @@ def yolo_parameter():
 '''.format(self.yolo_parameter))
 
 
-    def _layer_upsample(self):
+    def _layer_UpSampling2D(self):
         self.add_body(0, '''
 def Upsampling2D(x, stride, name):
     assert stride == 2


### PR DESCRIPTION
fix upsampling2d function name so that it is consistent with other naming conventions, this resolves this attribute error for some models: 

\site-packages\mmdnn\conversion\cntk\cntk_emitter.py", line 104, in gen_code
    func = getattr(self, "_layer_" + i)
AttributeError: 'CntkEmitter' object has no attribute '_layer_UpSampling2D'