### PR TITLE
add None comparison to tensorflow_frozenparser

### DIFF
--- a/mmdnn/conversion/tensorflow/tensorflow_frozenparser.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_frozenparser.py
@@ -490,7 +490,7 @@ class TensorflowParser2(Parser):
             return
 
         variable = self.check_const(self.tf_graph.get_node(add_node.in_edges[1])) #add_bias node
-        if variable.type != 'Const':
+        if not variable or variable.type != 'Const':
             return
 
 


### PR DESCRIPTION
This change provides more clear diagnostics messages if mmdnn can't convert tensorflow frozen model