### PR TITLE
Add support for unpooling import from caffe and export to pytorch

### DIFF
--- a/mmdnn/conversion/caffe/graph.py
+++ b/mmdnn/conversion/caffe/graph.py
@@ -89,6 +89,7 @@ LAYER_DESCRIPTORS = {
     'MultinomialLogisticLoss': shape_scalar,
     'MVN': shape_not_implemented,
     'Pooling': shape_pool,
+    'Unpooling': shape_unpool,
     'Power': shape_identity,
     'ReLU': shape_identity,
     'Scale': shape_identity,
@@ -191,7 +192,7 @@ class CaffeNode(object):
 
     @property
     def kernel_parameters(self):
-        assert self.kind in (NodeKind.Convolution, NodeKind.Pooling, NodeKind.Deconvolution)
+        assert self.kind in (NodeKind.Convolution, NodeKind.Pooling, NodeKind.Unpooling, NodeKind.Deconvolution)
         params = self.parameters
         global_pooling = hasattr(params, 'global_pooling') and params.global_pooling
         if not global_pooling:

--- a/mmdnn/conversion/caffe/mapper.py
+++ b/mmdnn/conversion/caffe/mapper.py
@@ -67,7 +67,7 @@ class NodeMapper(object):
             else:
                 o_h_tf = (input_shape.height + node.kernel_parameters.p_h * 2 - ko_h + 1) // node.kernel_parameters.s_h
                 o_w_tf = (input_shape.width + node.kernel_parameters.p_w * 2 - ko_w + 1) // node.kernel_parameters.s_w
-
+            
             kwargs['pads'] = [0, node.kernel_parameters.p_h, node.kernel_parameters.p_w, 0] + \
                     [0, node.kernel_parameters.p_h + o_h_caffe - o_h_tf, node.kernel_parameters.p_w + o_w_caffe - o_w_tf, 0]
 
@@ -181,6 +181,16 @@ class NodeMapper(object):
             raise ConversionError('Unsupported pooling type.')
         cls._convert_output_shape(kwargs, node)
         return Node.create('Pool', **kwargs)
+
+
+    @classmethod
+    def map_unpooling(cls, node):
+        kwargs = {}
+        kwargs['kernel_shape'] = [1, node.kernel_parameters.k_h, node.kernel_parameters.k_w, 1]
+        kwargs['pads'] = [0, node.kernel_parameters.p_h, node.kernel_parameters.p_w, 0]
+        kwargs['strides'] = [1, node.kernel_parameters.s_h, node.kernel_parameters.s_w, 1]
+        cls._convert_output_shape(kwargs, node)
+        return Node.create('Unpool', **kwargs)
 
 
     @classmethod

--- a/mmdnn/conversion/caffe/network.py
+++ b/mmdnn/conversion/caffe/network.py
@@ -70,6 +70,10 @@ class Network(object):
         raise NotImplementedError('Must be implemented by the subclass')
 
     @layer
+    def max_unpool(self, input, k_h, k_w, s_h, s_w, p_h, p_w, name):
+        raise NotImplementedError('Must be implemented by the subclass')
+
+    @layer
     def avg_pool(self, input, k_h, k_w, s_h, s_w, p_h, p_w, name):
         raise NotImplementedError('Must be implemented by the subclass')
 

--- a/mmdnn/conversion/caffe/shape.py
+++ b/mmdnn/conversion/caffe/shape.py
@@ -115,6 +115,8 @@ def shape_pool(node):
         return shape_global_pooling(node)
     return get_strided_kernel_output_shape(node, math.ceil)
 
+def shape_unpool(node):
+    return get_strided_kernel_output_shape(node, math.ceil)
 
 def shape_inner_product(node):
     input_shape = node.get_only_parent()[0].output_shape

--- a/mmdnn/conversion/caffe/transformer.py
+++ b/mmdnn/conversion/caffe/transformer.py
@@ -123,7 +123,7 @@ class DataReshaper(object):
             raise ConversionError('Ordering not found for node kind: {}'.format(node_kind))
 
     def _is_image_data(self, node):
-        return len([child for child in node.children if child.kind in (NodeKind.Convolution, NodeKind.Pooling)])
+        return len([child for child in node.children if child.kind in (NodeKind.Convolution, NodeKind.Pooling, NodeKind.Unpooling)])
 
     def __call__(self, graph):
         for node in graph.nodes:

--- a/mmdnn/conversion/common/IR/ops.pbtxt
+++ b/mmdnn/conversion/common/IR/ops.pbtxt
@@ -595,6 +595,63 @@ op {
 }
 
 op {
+  name: "Unpool"
+  attr {
+    name: "kernel_shape"
+    description: "Shape `[1, depth, height, wide, 1]`."
+    type: "list(int)"
+  }
+  attr {
+    name: "strides"
+    type: "list(int)"
+    description: "1-D tensor of length N.  [1, stride_deep, stride_height, stride_width, 1]"
+  }
+  attr {
+    name: "audo_pad"
+    type: "string"
+    description: "The type of padding algorithm to use."
+    allowed_values {
+      list {
+        s: "SAME_UPPER"
+        s: "SAME_LOWER"
+        s: "VALID"
+      }
+    }
+  }
+  attr {
+    name: "pads"
+    type: "list(int)"
+    description: "1-D tensor of length N*2. [x1_begin, x2_begin...x1_end, x2_end,...]"
+    allowed_values {
+      list {
+        i: 0
+        f: 0.0
+      }
+    }
+  }
+  attr {
+    name: "data_format"
+    type: "string"
+    default_value {
+      s: "NHWC"
+    }
+    allowed_values {
+      list {
+        s: "NC"
+        s: "NWC"
+        s: "NCW"
+        s: "NHWC"
+        s: "NCHW"
+        s: "NDHWC"
+        s: "NCDHW"
+      }
+    }
+  }
+  summary: "Performs an N-D unpooling operation."
+  description: "tf.nn.unpool defined"
+}
+
+op {
   name: "Mul"
   summary: "Returns x * y element-wise."
   description: "*NOTE*: `Mul` supports broadcasting. More about broadcasting[here](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html)"

--- a/mmdnn/conversion/pytorch/pytorch_emitter.py
+++ b/mmdnn/conversion/pytorch/pytorch_emitter.py
@@ -231,14 +231,16 @@ class KitModel(nn.Module):
                 pool_size = IR_node.get_attr('kernel_shape')[1:-1]
                 strides = IR_node.get_attr('strides')[1:-1]
 
-                code = "{:<15} = F.{}({}, kernel_size={}, stride={}, padding={}, ceil_mode={})".format(
+                code = "{}, {}_idx = F.{}({}, kernel_size={}, stride={}, padding={}, ceil_mode={}, return_indices={})".format(
+                    IR_node.variable_name,
                     IR_node.variable_name,
                     pool_name,
                     input_node,
                     tuple(pool_size),
                     tuple(strides),
                     0,
-                    False
+                    False,
+                    True
                     )
                 return code
 
@@ -266,6 +268,27 @@ class KitModel(nn.Module):
                 return code
             else:
                 raise ValueError()
+
+    def emit_Unpool(self, IR_node):
+        dim = len(IR_node.get_attr('strides')) - 2
+
+        # Change to padding defuse
+        input_node = self.parent_variable_name(IR_node)
+        index_node = self.parent_variable_name(IR_node,[1])
+        pool_name = "max_unpool{}d".format(dim)
+        pool_size = IR_node.get_attr('kernel_shape')[1:-1]
+        strides = IR_node.get_attr('strides')[1:-1]
+
+        code = "{:<15} = F.{}({},{}_idx, kernel_size={}, stride={}, padding={})".format(
+            IR_node.variable_name,
+            pool_name,
+            input_node,
+            index_node,
+            tuple(pool_size),
+            tuple(strides),
+            0
+            )
+        return code
 
 
     def emit_UNKNOWN(self, IR_node):


### PR DESCRIPTION
This pull requests enables support for unpooling layer and pooling layer with indexes from caffe with export to pytorch.

Corresponding issue #740 

Signed-off-by: Sebastien ESKENAZI <s.eskenaz@pixelz.com>