### PR TITLE
[README.md] Clarify license

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ Details are in [ops.txt](https://github.com/Microsoft/MMdnn/blob/master/mmdnn/co
 We are working on other frameworks conversion and visualization, such as PyTorch, CoreML and so on. We're investigating more RNN related operators. Any contributions and suggestions are welcome! Details in [Contribution Guideline](https://github.com/Microsoft/MMdnn/wiki/Contribution-Guideline).
 
 ### License
+The entire codebase is under [MIT license](LICENSE)
 
+### Contributions
 Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 


### PR DESCRIPTION
Other Microsoft projects—e.g., [nni](https://github.com/microsoft/nni/blob/5f5f86c/README.md#license)—are much clearer when it comes to license, I had to scroll to the top of the page to see MIT (from GitHub not in the README).