### PR TITLE
Fix issue 792

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ tests/tmp/
 
 # Visual Studio
 .vs/
+
+# macOS
+# Desktop Services Store files
+.DS_Store

--- a/mmdnn/conversion/tensorflow/tensorflow_frozenparser.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_frozenparser.py
@@ -560,6 +560,7 @@ class TensorflowParser2(Parser):
         weight_content = tensor_util.MakeNdarray(weight)
         self.set_weight(source_node.name, 'weights', weight_content)
         assign_IRnode_values(IR_node, kwargs)
+        self._get_bias(source_node, IR_node)
 
 
     def rename_BatchNormWithGlobalNormalization(self, source_node):

--- a/mmdnn/conversion/tensorflow/tensorflow_parser.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_parser.py
@@ -791,6 +791,7 @@ class TensorflowParser(Parser):
             self.set_weight(source_node.name, 'weights', self.ckpt_data[weight.name])
 
         assign_IRnode_values(IR_node, kwargs)
+        self._get_bias(source_node, IR_node)
 
 
     def rename_FusedBatchNorm(self, source_node):


### PR DESCRIPTION
Fix issue https://github.com/microsoft/MMdnn/issues/792
1. TensorFlow rename_DepthwiseConv2dNative() forgets to handle the bias.
2. Ignore macOS .DS_Store files.