### PR TITLE
Use keras.backends.image_data_format() since Keras >= 2.2.5 does not provide image_data_format() any more.

### DIFF
--- a/mmdnn/conversion/keras/keras2_emitter.py
+++ b/mmdnn/conversion/keras/keras2_emitter.py
@@ -1077,7 +1077,7 @@ class LRN(Layer):
         squared = K.square(x)
         scale = self.k
         norm_alpha = self.alpha / self.n
-        if K.image_dim_ordering() == "th":
+        if (K.image_data_format() == 'channels_first'):
             b, f, r, c = self.shape
             squared = K.expand_dims(squared, 0)
             squared = K.spatial_3d_padding(squared, padding=((half_n, half_n), (0, 0), (0,0)))


### PR DESCRIPTION
Fix issue https://github.com/microsoft/MMdnn/issues/847 .