### PR TITLE
Fix name mangling in KitModel

### DIFF
--- a/mmdnn/conversion/caffe/caffe_emitter.py
+++ b/mmdnn/conversion/caffe/caffe_emitter.py
@@ -47,7 +47,7 @@ from caffe import to_proto
 from six import text_type as _text_type
 
 
-__weights_dict = dict()
+_weights_dict = dict()
 
 def load_weights(weight_file):
     if weight_file == None:
@@ -75,25 +75,25 @@ def make_net(prototxt):
         print(n.to_proto(), file=fpb)
 
 def gen_weight(weight_file, model, prototxt):
-    global __weights_dict
-    __weights_dict = load_weights(weight_file)
+    global _weights_dict
+    _weights_dict = load_weights(weight_file)
 
     net = caffe.Net(prototxt, caffe.TRAIN)
 
-    for key in __weights_dict:
-        if 'weights' in __weights_dict[key]:
-            net.params[key][0].data.flat = __weights_dict[key]['weights']
-        elif 'mean' in __weights_dict[key]:
-            net.params[key][0].data.flat = __weights_dict[key]['mean']
-            net.params[key][1].data.flat = __weights_dict[key]['var']
-            if 'scale' in __weights_dict[key]:
-                net.params[key][2].data.flat = __weights_dict[key]['scale']
-        elif 'scale' in __weights_dict[key]:
-            net.params[key][0].data.flat = __weights_dict[key]['scale']
-        if 'bias' in __weights_dict[key]:
-            net.params[key][1].data.flat = __weights_dict[key]['bias']
-        if 'gamma' in __weights_dict[key]: # used for prelu, not sure if other layers use this too
-            net.params[key][0].data.flat = __weights_dict[key]['gamma']
+    for key in _weights_dict:
+        if 'weights' in _weights_dict[key]:
+            net.params[key][0].data.flat = _weights_dict[key]['weights']
+        elif 'mean' in _weights_dict[key]:
+            net.params[key][0].data.flat = _weights_dict[key]['mean']
+            net.params[key][1].data.flat = _weights_dict[key]['var']
+            if 'scale' in _weights_dict[key]:
+                net.params[key][2].data.flat = _weights_dict[key]['scale']
+        elif 'scale' in _weights_dict[key]:
+            net.params[key][0].data.flat = _weights_dict[key]['scale']
+        if 'bias' in _weights_dict[key]:
+            net.params[key][1].data.flat = _weights_dict[key]['bias']
+        if 'gamma' in _weights_dict[key]: # used for prelu, not sure if other layers use this too
+            net.params[key][0].data.flat = _weights_dict[key]['gamma']
     net.save(model)
     return net
 

--- a/mmdnn/conversion/cntk/README.md
+++ b/mmdnn/conversion/cntk/README.md
@@ -124,9 +124,9 @@ If you want to retrain the converted model, you can change all layers from "Chan
 from
 
 def batch_normalization(input, name, epsilon, **kwargs):
-    mean = cntk.Parameter(init = __weights_dict[name]['mean'],
+    mean = cntk.Parameter(init = _weights_dict[name]['mean'],
         name = name + "_mean")
-    var = cntk.Parameter(init = __weights_dict[name]['var'],
+    var = cntk.Parameter(init = _weights_dict[name]['var'],
         name = name + "_var")
     layer = (input - mean) / cntk.sqrt(var + epsilon)
 
@@ -136,10 +136,10 @@ to
 
 def batch_normalization(input, name, epsilon, **kwargs):
     layer = cntk.layers.BatchNormalization( map_rank = 1, name=name )(input)
-    mean = cntk.Parameter(init = __weights_dict[name]['mean'],
+    mean = cntk.Parameter(init = _weights_dict[name]['mean'],
         name = name + "_mean")
     layer.aggregate_mean = mean
-    var = cntk.Parameter(init = __weights_dict[name]['var'],
+    var = cntk.Parameter(init = _weights_dict[name]['var'],
         name = name + "_var")
     layer.aggregate_variance = var
     layer.aggregate_count    = 4096.0

--- a/mmdnn/conversion/onnx/onnx_emitter.py
+++ b/mmdnn/conversion/onnx/onnx_emitter.py
@@ -36,7 +36,7 @@ class OnnxEmitter(Emitter):
 from onnx import helper, TensorProto
 import onnx
 
-__weights_dict = dict()
+_weights_dict = dict()
 
 def load_weights(weight_file):
     if weight_file == None:
@@ -51,8 +51,8 @@ def load_weights(weight_file):
 
 
 def KitModel(weight_file = None):
-    global __weights_dict
-    __weights_dict = load_weights(weight_file)
+    global _weights_dict
+    _weights_dict = load_weights(weight_file)
 
 """
 
@@ -155,7 +155,7 @@ def KitModel(weight_file = None):
         pads = pads[1:pad_length // 2 - 1] + pads[pad_length // 2 + 1:pad_length - 1]
         strides = list(IR_node.get_attr('strides'))[1:-1]
         use_bias=IR_node.get_attr('use_bias')
-        self.add_body(1, "{:15} = __weights_dict['{}']['weights']".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['weights']".format(
             IR_node.variable_name + '_weight_array',
             IR_node.name))
         self.add_body(1, "{} = {}.transpose([3,2,0,1])".format(
@@ -175,7 +175,7 @@ def KitModel(weight_file = None):
                           IR_node.variable_name + '_weight_array'))
 
         if use_bias:
-            self.add_body(1, "{:15} = __weights_dict['{}']['bias'].squeeze()".format(
+            self.add_body(1, "{:15} = _weights_dict['{}']['bias'].squeeze()".format(
                 IR_node.variable_name + '_bias_array',
                 IR_node.name))
 
@@ -226,11 +226,11 @@ def KitModel(weight_file = None):
     def emit_BatchNorm(self, IR_node):
         epsilon = IR_node.get_attr('epsilon')
         if IR_node.get_attr('scale'):
-            self.add_body(1, "{:15} = __weights_dict['{}']['scale'].squeeze()".format(
+            self.add_body(1, "{:15} = _weights_dict['{}']['scale'].squeeze()".format(
                 IR_node.variable_name + '_scale_array',
                 IR_node.name))
         else:
-            self.add_body(1, "{:15} = np.ndarray(__weights_dict['{}']['bias'].shape, dtype=__weights_dict['{}']['bias'].dtype).squeeze()".format(
+            self.add_body(1, "{:15} = np.ndarray(_weights_dict['{}']['bias'].shape, dtype=_weights_dict['{}']['bias'].dtype).squeeze()".format(
                               IR_node.variable_name + '_scale_array',
                               IR_node.name,
                               IR_node.name))
@@ -248,7 +248,7 @@ def KitModel(weight_file = None):
                           IR_node.variable_name + '_scale_array',
                           IR_node.variable_name + '_scale_array',
                           IR_node.variable_name + '_scale_array'))
-        self.add_body(1, "{:15} = __weights_dict['{}']['bias'].squeeze()".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['bias'].squeeze()".format(
             IR_node.variable_name + '_bias_array',
             IR_node.name))
         self.add_body(1, "{:15} = helper.make_tensor_value_info('{}', onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[{}.dtype], list({}.shape))".format(
@@ -264,7 +264,7 @@ def KitModel(weight_file = None):
                             IR_node.variable_name + '_bias_array',
                             IR_node.variable_name + '_bias_array'))
 
-        self.add_body(1, "{:15} = __weights_dict['{}']['mean'].squeeze()".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['mean'].squeeze()".format(
             IR_node.variable_name + '_mean_array',
             IR_node.name))
         self.add_body(1, "{:15} = helper.make_tensor_value_info('{}', onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[{}.dtype], list({}.shape))".format(
@@ -280,7 +280,7 @@ def KitModel(weight_file = None):
                             IR_node.variable_name + '_mean_array',
                             IR_node.variable_name + '_mean_array'))
 
-        self.add_body(1, "{:15} = __weights_dict['{}']['var'].squeeze()".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['var'].squeeze()".format(
                           IR_node.variable_name + '_var_array',
                           IR_node.name))
         self.add_body(1, "{:15} = helper.make_tensor_value_info('{}', onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[{}.dtype], list({}.shape))".format(
@@ -323,11 +323,11 @@ def KitModel(weight_file = None):
         units = dims[-1]
         epsilon = 1e-5
         if IR_node.get_attr('scale'):
-            self.add_body(1, "{:15} = __weights_dict['{}']['scale'].squeeze()".format(
+            self.add_body(1, "{:15} = _weights_dict['{}']['scale'].squeeze()".format(
                 IR_node.variable_name + '_scale_array',
                 IR_node.name))
         else:
-            self.add_body(1, "{:15} = np.ndarray(__weights_dict['{}']['bias'].shape, dtype=__weights_dict['{}']['bias'].dtype).squeeze()".format(
+            self.add_body(1, "{:15} = np.ndarray(_weights_dict['{}']['bias'].shape, dtype=_weights_dict['{}']['bias'].dtype).squeeze()".format(
                               IR_node.variable_name + '_scale_array',
                               IR_node.name,
                               IR_node.name))
@@ -344,7 +344,7 @@ def KitModel(weight_file = None):
                             IR_node.variable_name + '_scale_array',
                             IR_node.variable_name + '_scale_array',
                             IR_node.variable_name + '_scale_array'))
-        self.add_body(1, "{:15} = __weights_dict['{}']['bias'].squeeze()".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['bias'].squeeze()".format(
             IR_node.variable_name + '_bias_array',
             IR_node.name))
         self.add_body(1, "{:15} = helper.make_tensor_value_info('{}', onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[{}.dtype], list({}.shape))".format(
@@ -473,7 +473,7 @@ def KitModel(weight_file = None):
         use_bias = IR_node.get_attr('use_bias', True)
         units = IR_node.get_attr('units')
 
-        self.add_body(1, "{:15} = __weights_dict['{}']['weights']".format(
+        self.add_body(1, "{:15} = _weights_dict['{}']['weights']".format(
             IR_node.variable_name + '_weight_array',
             IR_node.name))
 
@@ -491,7 +491,7 @@ def KitModel(weight_file = None):
             IR_node.variable_name + '_weight_array'))
 
         if use_bias:
-            self.add_body(1, "{:15} = __weights_dict['{}']['bias'].squeeze()".format(
+            self.add_body(1, "{:15} = _weights_dict['{}']['bias'].squeeze()".format(
                 IR_node.variable_name + '_bias_array',
                 IR_node.name))
         else:
@@ -571,7 +571,7 @@ def KitModel(weight_file = None):
                 IR_node.variable_name + '_value_array',
                 value))
         else:
-            self.add_body(1, "{:15} = __weights_dict['{}']['value']".format(
+            self.add_body(1, "{:15} = _weights_dict['{}']['value']".format(
                 IR_node.variable_name + '_value_array',
                 IR_node.name))
         self.add_body(1, "{:15} = helper.make_node('Constant', inputs=[], outputs=['{}'], value=helper.make_tensor(name='const_tensor', data_type=onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[{}.dtype], dims={}.shape, vals={}.flatten().astype(float)), name='{}')".format(
@@ -596,7 +596,7 @@ def KitModel(weight_file = None):
         inputs = ', '.join("'" + self.IR_graph.get_node(i).real_variable_name + "'" for i in IR_node.in_edges)
         
         if IR_node.name in self.weights_dict and 'weights' in self.weights_dict[IR_node.name]:
-            self.add_body(1,"{:15} = np.array([__weights_dict['{}']['weights']])".format(
+            self.add_body(1,"{:15} = np.array([_weights_dict['{}']['weights']])".format(
                 IR_node.variable_name+'_weight_array',
                 IR_node.name
             ))

--- a/mmdnn/conversion/tensorflow/tensorflow_emitter.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_emitter.py
@@ -31,7 +31,7 @@ class TensorflowEmitter(Emitter):
     def header_code(self):
         return """import tensorflow as tf
 
-__weights_dict = dict()
+_weights_dict = dict()
 
 is_train = {}
 
@@ -50,8 +50,8 @@ def load_weights(weight_file):
 
 
 def KitModel(weight_file = None):
-    global __weights_dict
-    __weights_dict = load_weights(weight_file)
+    global _weights_dict
+    _weights_dict = load_weights(weight_file)
 """.format(self.trainable)
 
 
@@ -109,7 +109,7 @@ def KitModel(weight_file = None):
 
     def parent_variable_name(self, IR_node, path=[0]):
         if not IR_node.in_edges and IR_node.name in self.weights_dict.keys():
-            return "tf.constant(__weights_dict['{}']['weights'], name='{}')".format(
+            return "tf.constant(_weights_dict['{}']['weights'], name='{}')".format(
                 IR_node.name,
                 IR_node.name)
         return super(TensorflowEmitter, self).parent_variable_name(IR_node, path)
@@ -172,7 +172,7 @@ def KitModel(weight_file = None):
             dtype_str = "tf.float32"
         code = "{:<15} = tf.constant({}, dtype={}, name='{}')".format(
             IR_node.variable_name,
-            "__weights_dict['{}']['value']".format(IR_node.name) if IR_node.get_attr('value')== None else IR_node.get_attr('value'),
+            "_weights_dict['{}']['value']".format(IR_node.name) if IR_node.get_attr('value')== None else IR_node.get_attr('value'),
             dtype_str,
             IR_node.name)
 
@@ -280,11 +280,11 @@ def KitModel(weight_file = None):
 
     def emit_FullyConnected(self, IR_node):
         if IR_node.name in self.weights_dict and 'weights' in self.weights_dict[IR_node.name]:
-            kernel_str = "kernel_initializer = tf.constant_initializer(__weights_dict['{}']['weights']), ".format(IR_node.name)
+            kernel_str = "kernel_initializer = tf.constant_initializer(_weights_dict['{}']['weights']), ".format(IR_node.name)
         else: kernel_str = ""
 
         if IR_node.name in self.weights_dict and 'bias' in self.weights_dict[IR_node.name]:
-            bias_str = "bias_initializer = tf.constant_initializer(__weights_dict['{}']['bias']), ".format(IR_node.name)
+            bias_str = "bias_initializer = tf.constant_initializer(_weights_dict['{}']['bias']), ".format(IR_node.name)
         else: bias_str = ""
 
         # check whether flatten operator should be added
@@ -373,7 +373,7 @@ def KitModel(weight_file = None):
         return code
 
     def emit_Gather(self, IR_node):
-        variable_str = "tf.convert_to_tensor(__weights_dict['{}']['weights'])".format(IR_node.name)
+        variable_str = "tf.convert_to_tensor(_weights_dict['{}']['weights'])".format(IR_node.name)
 
         code = "{:<15} = tf.gather(params = {}, indices = {}, axis = {})".format(
             IR_node.variable_name,
@@ -473,7 +473,7 @@ def KitModel(weight_file = None):
         return code
 
     def emit_Embedding(self, IR_node):
-        variable_str = "tf.convert_to_tensor(__weights_dict['{}']['weights'])".format(IR_node.name)
+        variable_str = "tf.convert_to_tensor(_weights_dict['{}']['weights'])".format(IR_node.name)
         code = "{:<15} = tf.nn.embedding_lookup(params = {}, ids = {})".format(
             IR_node.variable_name,
             variable_str,
@@ -726,7 +726,7 @@ def KitModel(weight_file = None):
 
     def emit_Scope(self, IR_node):
         input_vars = [self.parent_variable_name(IR_node, [idx]) for idx in range(len(IR_node.in_edges))]
-        input_vars.append('__weights_dict')
+        input_vars.append('_weights_dict')
         code = "{:<15} = _{}({})".format(
             IR_node.real_variable_name,
             IR_node.pattern,
@@ -762,7 +762,7 @@ def _{}({}):
 
             # param_code does not need parameter slice.
             input_params = scope_node.input_params
-            input_params.append("__weights_dict")
+            input_params.append("_weights_dict")
             param_code = ', '.join(input_params)
             function_code = _scope_func(scope_node.pattern, param_code, body_code, scope_node.return_variables)
 
@@ -773,7 +773,7 @@ def _{}({}):
     def _layer_Conv(self):
         self.add_body(0, """
 def convolution(input, name, group, **kwargs):
-    w = tf.Variable(__weights_dict[name]['weights'], trainable=is_train, name=name + "_weight")
+    w = tf.Variable(_weights_dict[name]['weights'], trainable=is_train, name=name + "_weight")
     if group == 1:
         layer = tf.nn.convolution(input, w, name=name, **kwargs)
     else:
@@ -783,8 +783,8 @@ def convolution(input, name, group, **kwargs):
                     (x, weight) in zip(xs, weight_groups)]
         layer = tf.concat(convolved, axis=-1)
 
-    if 'bias' in __weights_dict[name]:
-        b = tf.Variable(__weights_dict[name]['bias'], trainable=is_train, name=name + "_bias")
+    if 'bias' in _weights_dict[name]:
+        b = tf.Variable(_weights_dict[name]['bias'], trainable=is_train, name=name + "_bias")
         layer = layer + b
     return layer""")
 
@@ -792,7 +792,7 @@ def convolution(input, name, group, **kwargs):
     def _layer_PRelu(self):
         self.add_body(0, """
 def prelu(input, name):
-    gamma = tf.Variable(__weights_dict[name]['gamma'], name=name + "_gamma", trainable=is_train)
+    gamma = tf.Variable(_weights_dict[name]['gamma'], name=name + "_gamma", trainable=is_train)
     return tf.maximum(0.0, input) + gamma * tf.minimum(0.0, input)
     """)
 
@@ -800,10 +800,10 @@ def prelu(input, name):
     def _layer_BatchNorm(self):
         self.add_body(0, """
 def batch_normalization(input, name, **kwargs):
-    mean = tf.Variable(__weights_dict[name]['mean'], name = name + "_mean", trainable = is_train)
-    variance = tf.Variable(__weights_dict[name]['var'], name = name + "_var", trainable = is_train)
-    offset = tf.Variable(__weights_dict[name]['bias'], name = name + "_bias", trainable = is_train) if 'bias' in __weights_dict[name] else None
-    scale = tf.Variable(__weights_dict[name]['scale'], name = name + "_scale", trainable = is_train) if 'scale' in __weights_dict[name] else None
+    mean = tf.Variable(_weights_dict[name]['mean'], name = name + "_mean", trainable = is_train)
+    variance = tf.Variable(_weights_dict[name]['var'], name = name + "_var", trainable = is_train)
+    offset = tf.Variable(_weights_dict[name]['bias'], name = name + "_bias", trainable = is_train) if 'bias' in _weights_dict[name] else None
+    scale = tf.Variable(_weights_dict[name]['scale'], name = name + "_scale", trainable = is_train) if 'scale' in _weights_dict[name] else None
     return tf.nn.batch_normalization(input, mean, variance, offset, scale, name = name, **kwargs)
 """)
 
@@ -811,10 +811,10 @@ def batch_normalization(input, name, **kwargs):
     def _layer_Scale(self):
         self.add_body(0, """
 def scale(input, name, **kwargs):
-    mean = tf.Variable(__weights_dict[name]['scale_mean'], name = name + "_mean", trainable = is_train)
-    variance = tf.Variable(__weights_dict[name]['scale_var'], name = name + "_var", trainable = is_train)
-    offset = tf.Variable(__weights_dict[name]['bias'], name = name + "_bias", trainable = is_train) if 'bias' in __weights_dict[name] else None
-    scale = tf.Variable(__weights_dict[name]['scale'], name = name + "_scale", trainable = is_train) if 'scale' in __weights_dict[name] else None
+    mean = tf.Variable(_weights_dict[name]['scale_mean'], name = name + "_mean", trainable = is_train)
+    variance = tf.Variable(_weights_dict[name]['scale_var'], name = name + "_var", trainable = is_train)
+    offset = tf.Variable(_weights_dict[name]['bias'], name = name + "_bias", trainable = is_train) if 'bias' in _weights_dict[name] else None
+    scale = tf.Variable(_weights_dict[name]['scale'], name = name + "_scale", trainable = is_train) if 'scale' in _weights_dict[name] else None
     return tf.nn.batch_normalization(input, mean, variance, offset, scale, variance_epsilon = 0, name = name)
 """)
 
@@ -822,11 +822,11 @@ def scale(input, name, **kwargs):
     def _layer_SeparableConv(self):
         self.add_body(0, """
 def separable_convolution(input, name, **kwargs):
-    depthwise = tf.Variable(__weights_dict[name]['depthwise_filter'], trainable = is_train, name = name + "_df")
-    pointwise = tf.Variable(__weights_dict[name]['pointwise_filter'], trainable = is_train, name = name + "_pf")
+    depthwise = tf.Variable(_weights_dict[name]['depthwise_filter'], trainable = is_train, name = name + "_df")
+    pointwise = tf.Variable(_weights_dict[name]['pointwise_filter'], trainable = is_train, name = name + "_pf")
     layer = tf.nn.separable_conv2d(input, depthwise, pointwise, **kwargs)
-    if 'bias' in __weights_dict[name]:
-        b = tf.Variable(__weights_dict[name]['bias'], trainable = is_train, name = name + "_bias")
+    if 'bias' in _weights_dict[name]:
+        b = tf.Variable(_weights_dict[name]['bias'], trainable = is_train, name = name + "_bias")
         layer = layer + b
     return layer""")
 
@@ -834,10 +834,10 @@ def separable_convolution(input, name, **kwargs):
     def _layer_DepthwiseConv(self):
         self.add_body(0, """
 def depthwise_convolution(input, name, **kwargs):
-    depthwise = tf.Variable(__weights_dict[name]['weights'], trainable = is_train, name = name + "_df")
+    depthwise = tf.Variable(_weights_dict[name]['weights'], trainable = is_train, name = name + "_df")
     layer = tf.nn.depthwise_conv2d(input, depthwise, **kwargs)
-    if 'bias' in __weights_dict[name]:
-        b = tf.Variable(__weights_dict[name]['bias'], trainable = is_train, name = name + "_bias")
+    if 'bias' in _weights_dict[name]:
+        b = tf.Variable(_weights_dict[name]['bias'], trainable = is_train, name = name + "_bias")
         layer = layer + b
     return layer""")
 
@@ -845,8 +845,8 @@ def depthwise_convolution(input, name, **kwargs):
     def _layer_ConvTranspose(self):
         self.add_body(0, """
 def convolution_transpose(input, name, **kwargs):
-    w = tf.Variable(__weights_dict[name]['weights'], trainable=is_train, name=name + "_weight")
-    dim = __weights_dict[name]['weights'].ndim - 2
+    w = tf.Variable(_weights_dict[name]['weights'], trainable=is_train, name=name + "_weight")
+    dim = _weights_dict[name]['weights'].ndim - 2
     if dim == 2:
         layer = tf.nn.conv2d_transpose(input, w, **kwargs)
     elif dim == 3:
@@ -854,7 +854,7 @@ def convolution_transpose(input, name, **kwargs):
     else:
         raise ValueError("Error dim number {} in ConvTranspose".format(dim))
 
-    if 'bias' in __weights_dict[name]:
-        b = tf.Variable(__weights_dict[name]['bias'], trainable=is_train, name=name + "_bias")
+    if 'bias' in _weights_dict[name]:
+        b = tf.Variable(_weights_dict[name]['bias'], trainable=is_train, name=name + "_bias")
         layer = layer + b
     return layer""")


### PR DESCRIPTION
This PR fixes an issue in all converter generators using ``KitModel``+``__weights_dict`` architecture. See issues #668 and #631. 

The error is due to the original code erroneously using a double-underscore name at global and class scope. [At class scope, double-underscore names are subject to name mangling](https://docs.python.org/3/tutorial/classes.html#private-variables); this leads the variable at global and class scope to *not* be equivalent.