### PR TITLE
Add support for mxnet UpSampling parser

### DIFF
--- a/mmdnn/conversion/mxnet/mxnet_parser.py
+++ b/mmdnn/conversion/mxnet/mxnet_parser.py
@@ -822,6 +822,17 @@ class MXNetParser(Parser):
     Here start with Symbol manipulation routines
     """
 
+    def rename_UpSampling(self, source_node):
+        IR_node = self._convert_identity_operation(source_node, new_op="UpSampling2D")
+        kwargs = dict()
+        scale = int(source_node.get_attr("scale"))
+        interpolation_type = source_node.get_attr("sample_type")
+        scales = [scale, scale]
+        kwargs["scales"] = scales
+        kwargs["interpolation_type"] = interpolation_type
+        assign_IRnode_values(IR_node, kwargs)
+
+
     # reverse cannot support yet
     def rename_reshape(self, source_node):
         IR_node = self._convert_identity_operation(source_node, new_op='Reshape')

--- a/mmdnn/conversion/tensorflow/tensorflow_emitter.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_emitter.py
@@ -324,7 +324,7 @@ def KitModel(weight_file = None):
             assert interpolation_type in ["nearest", "bilinear"]
         else:
             interpolation_type = "nearest"
-        code = "{:<15} = tf.keras.layers.UpSampling2D(size={}, interpolation={})({})".format(
+        code = "{:<15} = tf.keras.layers.UpSampling2D(size={}, interpolation='{}')({})".format(
             IR_node.variable_name,
             scales,
             interpolation_type,

--- a/mmdnn/conversion/tensorflow/tensorflow_emitter.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_emitter.py
@@ -319,12 +319,16 @@ def KitModel(weight_file = None):
     def emit_UpSampling2D(self, IR_node):
         scales = IR_node.get_attr('scales')
         scales = tuple(scales)
-
-        code = "{:<15} = tf.keras.layers.UpSampling2D(size={})({})".format(
+        interpolation_type = IR_node.get_attr('interpolation_type')
+        if interpolation_type not in ["nearest", "bilinear"]:
+            interpolation_type = "nearest"
+        code = "{:<15} = tf.keras.layers.UpSampling2D(size={}, interpolation={})({})".format(
             IR_node.variable_name,
             scales,
+            interpolation_type,
             self.parent_variable_name(IR_node))
         return code
+
 
     def emit_Flatten(self, IR_node):
         #self._emit_unary_operation(IR_node, "contrib.layers.flatten")

--- a/mmdnn/conversion/tensorflow/tensorflow_emitter.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_emitter.py
@@ -320,7 +320,9 @@ def KitModel(weight_file = None):
         scales = IR_node.get_attr('scales')
         scales = tuple(scales)
         interpolation_type = IR_node.get_attr('interpolation_type')
-        if interpolation_type not in ["nearest", "bilinear"]:
+        if interpolation_type:
+            assert interpolation_type in ["nearest", "bilinear"]
+        else:
             interpolation_type = "nearest"
         code = "{:<15} = tf.keras.layers.UpSampling2D(size={}, interpolation={})({})".format(
             IR_node.variable_name,


### PR DESCRIPTION
Hello

This pull requests adds the UpSampling operator to the mxnet parser, as well as the option to chose between "bilinear" and "nearest" when emitting the UpSampling2D operator to tensorflow
The mxnet operator is necessary to convert [insightface's Retinaface](RetinaFace) from mxnet to tf  
