### PR TITLE
update for tensorflow v2 compatibility

### DIFF
--- a/mmdnn/conversion/tensorflow/saver.py
+++ b/mmdnn/conversion/tensorflow/saver.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 
 def save_model(MainModel, network_filepath, weight_filepath, dump_filepath, dump_tag = 'SERVING'):

--- a/mmdnn/conversion/tensorflow/tensorflow_parser.py
+++ b/mmdnn/conversion/tensorflow/tensorflow_parser.py
@@ -4,7 +4,7 @@
 #----------------------------------------------------------------------------------------------
 
 import numpy as np
-import tensorflow
+import tensorflow.compat.v1 as tensorflow
 from tensorflow.python.framework import tensor_util
 from tensorflow.core.framework import attr_value_pb2
 from mmdnn.conversion.tensorflow.tensorflow_graph import TensorflowGraph


### PR DESCRIPTION
This PR updates `MMdnn` for `TensorFlow` **v2** compatibility by utilizing legacy support in TF2  

Main reason is that TF1 requires Python 3.7 or lower and new systems come with Python 3.8 which I did not want to downgrade  

Change is basically switching imports from `tensorflow` to `tensorflow.compat.v1` and setting appropriate flags  
Only additional change needed is definition of `flatten` layer as it has to be explicitly defined as legacy since `contrib` namespace no longer exists  

Additional change in this PR is that emitted code does not use `Inf` constant as any constant may be undefined depending on the backend used  

For example, Python or NodeJS with Tensorflow backend will resolve it fine, but GLSL code generated by TensorFlow/JS WebGL backend does not handle constants as constants in general do not exist in GLSL)

I've tested this with converting Places365 ResNet152 model from Caffe to Tensorflow saved model and further using `tensorflowjs_convert` to convert this new TF saved model to TFJS graph model and then tested using NodeJS `TensorFlow` backend, `WASM` backend and `WebGL` backend
